### PR TITLE
chore: Makefile and README - add Homebrew installation instructions

### DIFF
--- a/Formula/osheet2xlsx.rb
+++ b/Formula/osheet2xlsx.rb
@@ -1,0 +1,28 @@
+class Osheet2xlsx < Formula
+  desc "Convert Osheet (.osheet) files to Excel (.xlsx)"
+  homepage "https://github.com/romanitalian/osheet2xlsx"
+  head "https://github.com/romanitalian/osheet2xlsx.git", branch: "main"
+
+  depends_on "go" => :build
+
+  def install
+    commit = Utils.git_head || "unknown"
+    build_time = Time.now.utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+    ver = version || "HEAD"
+    ldflags = [
+      "-s -w",
+      "-X github.com/romanitalian/osheet2xlsx/v2/cmd.version=#{ver}",
+      "-X github.com/romanitalian/osheet2xlsx/v2/cmd.commit=#{commit}",
+      "-X github.com/romanitalian/osheet2xlsx/v2/cmd.date=#{build_time}",
+    ].join(" ")
+
+    system "go", "build", "-trimpath", "-o", bin/"osheet2xlsx", "-ldflags", ldflags, "."
+  end
+
+  test do
+    output = shell_output("#{bin}/osheet2xlsx version")
+    assert_match "version:", output
+  end
+end
+
+

--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,28 @@ ci-examples-test: ## Test examples for CI
 ci-examples-clean: ## Clean examples for CI
 	rm -rf outputs/
 
+##@ Homebrew (local)
+
+.PHONY: brew-install-local
+brew-install-local: ## Install via Homebrew from local Formula (HEAD, build-from-source)
+	brew install --HEAD --build-from-source ./Formula/osheet2xlsx.rb | cat
+
+.PHONY: brew-reinstall-local
+brew-reinstall-local: ## Reinstall via Homebrew from local Formula (HEAD)
+	brew reinstall --HEAD --build-from-source ./Formula/osheet2xlsx.rb | cat
+
+.PHONY: brew-uninstall
+brew-uninstall: ## Uninstall Homebrew formula
+	-brew uninstall osheet2xlsx | cat
+
+.PHONY: brew-audit-local
+brew-audit-local: ## Audit local formula (strict)
+	brew audit --strict --online ./Formula/osheet2xlsx.rb | cat
+
+.PHONY: brew-test
+brew-test: ## Run brew test block for the formula
+	brew test osheet2xlsx | cat
+
 ##@ Aliases
 
 .PHONY: r

--- a/README.md
+++ b/README.md
@@ -37,7 +37,24 @@ Osheet is a ZIP container with spreadsheet data. This tool:
 
 ## Installation
 
-### Option 1: build from source
+### Option 1: Homebrew (HEAD from main)
+
+Install from local formula (HEAD, build-from-source):
+
+```bash
+brew install --HEAD --build-from-source ./Formula/osheet2xlsx.rb
+osheet2xlsx version
+```
+
+Or via raw URL (without tap):
+
+```bash
+brew install --HEAD --build-from-source https://raw.githubusercontent.com/romanitalian/osheet2xlsx/main/Formula/osheet2xlsx.rb
+```
+
+Note: this installs the latest `main` (head). Stable bottles will appear after first release and move to a dedicated tap.
+
+### Option 2: build from source
 
 ```bash
 git clone https://github.com/romanitalian/osheet2xlsx.git
@@ -48,7 +65,7 @@ go build -o osheet2xlsx .
 
 On Windows replace `./osheet2xlsx` with `osheet2xlsx.exe`.
 
-### Option 2: local development
+### Option 3: local development
 
 ```bash
 # Clone and install locally
@@ -57,7 +74,7 @@ cd osheet2xlsx
 go install .
 ```
 
-### Option 3: go install
+### Option 4: go install
 
 ```bash
 # This will work after first release is created


### PR DESCRIPTION
**Title**
feat(brew): add Homebrew formula and install docs/targets

**Summary**
Add a head-only Homebrew formula for osheet2xlsx, Makefile targets to manage local brew install/audit/test, and README instructions for installing via Homebrew. Enables easy install on macOS via brew from the main branch.

**Motivation**
Simplify installation for macOS users.
Provide a reproducible build path via Homebrew until stable releases are published.
Prepare the project for future tap/stable bottle workflow.